### PR TITLE
client: don't pass the customerId in the update call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.kill-bill.billing</groupId>
         <artifactId>killbill-oss-parent</artifactId>
-        <version>0.144.48</version>
+        <version>0.144.59</version>
     </parent>
     <groupId>org.kill-bill.billing.plugin.java</groupId>
     <artifactId>braintree-plugin</artifactId>
@@ -40,8 +40,8 @@
             <version>3.5.0</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>org.osgi.core</artifactId>
                     <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -109,8 +109,8 @@
             <version>3.13.5</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>reactive-streams</artifactId>
                     <groupId>org.reactivestreams</groupId>
+                    <artifactId>reactive-streams</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -269,7 +269,7 @@
                         <exception>
                             <groupId>org.jooq</groupId>
                             <artifactId>jooq</artifactId>
-                            <expectedVersion>3.14.7</expectedVersion>
+                            <expectedVersion>3.14.13</expectedVersion>
                             <resolvedVersion>3.13.5</resolvedVersion>
                         </exception>
                     </exceptions>

--- a/src/main/java/org/killbill/billing/plugin/braintree/api/BraintreePaymentPluginApi.java
+++ b/src/main/java/org/killbill/billing/plugin/braintree/api/BraintreePaymentPluginApi.java
@@ -263,14 +263,17 @@ public class BraintreePaymentPluginApi extends PluginPaymentPluginApi<BraintreeR
 		if(!braintreeCustomerId.equals(BraintreePluginProperties.PROPERTY_FALLBACK_VALUE)){
 			setCustomerIdCustomField(braintreeCustomerId, kbAccountId, context);
 		}
-		if(paymentMethodProps != null && paymentMethodProps.getExternalPaymentMethodId() != null && !paymentMethodProps.getExternalPaymentMethodId().equals(kbPaymentMethodId.toString())){
-			//Payment method was created in Braintree. Synchronize the payment method ID and create in KillBill only
-			try{
-				Result<? extends PaymentMethod> result = braintreeClient.updatePaymentMethod(paymentMethodProps.getExternalPaymentMethodId(),
-						kbPaymentMethodId.toString(), getCustomerIdCustomField(kbAccountId, context));
-				if(!result.isSuccess()) throw new BraintreeException(result.getMessage());
-			}
-			catch (BraintreeException e){
+		if (paymentMethodProps != null &&
+			paymentMethodProps.getExternalPaymentMethodId() != null &&
+			!paymentMethodProps.getExternalPaymentMethodId().equals(kbPaymentMethodId.toString())) {
+			// Payment method was created in Braintree. Synchronize the payment method ID and create in KillBill only
+			try {
+				final Result<? extends PaymentMethod> result = braintreeClient.updatePaymentMethod(paymentMethodProps.getExternalPaymentMethodId(),
+																								   kbPaymentMethodId.toString());
+				if (!result.isSuccess()) {
+					throw new BraintreeException(result.getMessage());
+				}
+			} catch (final BraintreeException e) {
 				throw new PaymentPluginApiException("Could not update payment method in Braintree", e);
 			}
 		}

--- a/src/main/java/org/killbill/billing/plugin/braintree/client/BraintreeClient.java
+++ b/src/main/java/org/killbill/billing/plugin/braintree/client/BraintreeClient.java
@@ -40,7 +40,7 @@ public interface BraintreeClient {
 
     Result<? extends PaymentMethod> createPaymentMethod(String braintreeCustomerId, String braintreePaymentMethodToken, String braintreeNonce, PaymentMethodType paymentMethodType) throws BraintreeException;
 
-    Result<? extends PaymentMethod> updatePaymentMethod(String currentBraintreePaymentMethodToken, String newBraintreePaymentMethodToken, String newCustomerId) throws BraintreeException;
+    Result<? extends PaymentMethod> updatePaymentMethod(String currentBraintreePaymentMethodToken, String newBraintreePaymentMethodToken) throws BraintreeException;
 
     List<? extends PaymentMethod> getPaymentMethods(String braintreeCustomerId) throws BraintreeException;
 

--- a/src/main/java/org/killbill/billing/plugin/braintree/client/BraintreeClientImpl.java
+++ b/src/main/java/org/killbill/billing/plugin/braintree/client/BraintreeClientImpl.java
@@ -167,23 +167,20 @@ public class BraintreeClientImpl implements BraintreeClient {
     }
 
     @Override
-    public Result<? extends PaymentMethod> updatePaymentMethod(String currentBraintreePaymentMethodToken, String newBraintreePaymentMethodToken, String newCustomerId) throws BraintreeException {
-        Result<? extends PaymentMethod> result;
-        try{
-            PaymentMethodRequest request = new PaymentMethodRequest()
-                    .customerId(newCustomerId)
+    public Result<? extends PaymentMethod> updatePaymentMethod(final String currentBraintreePaymentMethodToken,
+                                                               final String newBraintreePaymentMethodToken) throws BraintreeException {
+        try {
+            // Note: do NOT pass the customerId here, as if the default payment method on the customer isn't a CC, the call would fail (even if the token here is a CC).
+            final PaymentMethodRequest request = new PaymentMethodRequest()
                     .token(newBraintreePaymentMethodToken)
                     .options()
                     .verifyCard(false) // Skip verification in the sync call
                     .done();
 
-            result = gateway.paymentMethod().update(currentBraintreePaymentMethodToken, request);
+            return gateway.paymentMethod().update(currentBraintreePaymentMethodToken, request);
+        } catch (final Throwable t) {
+            throw new BraintreeException("Could not update Braintree payment method token " + currentBraintreePaymentMethodToken + " to " + newBraintreePaymentMethodToken, t);
         }
-        catch(Throwable t){
-            throw new BraintreeException("Could not synchronize KillBill payment method " + newBraintreePaymentMethodToken + " with Braintree payment method " + currentBraintreePaymentMethodToken, t);
-        }
-
-        return result;
     }
 
     @Override


### PR DESCRIPTION
According to Braintree support, this can cause issues in their backend, leading to error 91738:
```
  Payment method is not a credit card payment method.
```
even though the token being updated refers to a CC.
